### PR TITLE
add support for placeholder templates that display while the template…

### DIFF
--- a/include_by_ajax/__init__.py
+++ b/include_by_ajax/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: UTF-8 -*-
 from __future__ import unicode_literals
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 default_app_config = 'include_by_ajax.apps.IncludeByAjaxConfig'

--- a/include_by_ajax/templates/include_by_ajax/includes/placeholder.html
+++ b/include_by_ajax/templates/include_by_ajax/includes/placeholder.html
@@ -7,6 +7,8 @@
         <section class="js-ajax-placeholder ajax-placeholder">
             {% if include_by_ajax_full_render %}
                 {% include template_name %}
+            {% elif placeholder_template_name %}
+                {% include placeholder_template_name %}
             {% endif %}
         </section>
     {% endif %}

--- a/include_by_ajax/templatetags/include_by_ajax_tags.py
+++ b/include_by_ajax/templatetags/include_by_ajax_tags.py
@@ -7,7 +7,7 @@ register = template.Library()
 
 
 @register.inclusion_tag('include_by_ajax/includes/placeholder.html', takes_context=True)
-def include_by_ajax(context, template_name):
+def include_by_ajax(context, template_name, placeholder_template_name=None):
     # get the app configuration
     app_config = apps.get_app_config('include_by_ajax')
     # get User-Agent
@@ -22,6 +22,7 @@ def include_by_ajax(context, template_name):
     )
     # in case of web crawler, the placeholder shouldn't be wrapped with a <section>
     context['include_by_ajax_no_placeholder_wrapping'] = is_web_crawler
-    # pass down the template path
+    # pass down the template paths
     context['template_name'] = template_name
+    context['placeholder_template_name'] = placeholder_template_name
     return context

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.4.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(
     name='django-include-by-ajax',
     packages=find_packages(include=['include_by_ajax']),
     url='https://github.com/archatas/django-include-by-ajax',
-    version='0.4.0',
+    version='0.4.1',
     zip_safe=False,
 )


### PR DESCRIPTION
… is loading via ajax and is replaced once it is loaded fully

My use case is to have some placeholder that takes up space and shows something like a loading spinner while the content is loading, so it's not just blank while the user waits.